### PR TITLE
Wallets - return all wallets

### DIFF
--- a/src/CrossmintEmbed.ts
+++ b/src/CrossmintEmbed.ts
@@ -18,7 +18,7 @@ export default class CrossmintEmbed {
         const { environment, chain, projectId } = this._config;
         const projectIdQueryParam = projectId != null ? `&projectId=${projectId}` : "";
 
-        return `${environment}/frame/2023-06-09?chain=${chain}${projectIdQueryParam}`;
+        return `${environment}/2023-06-09/frame?chain=${chain}${projectIdQueryParam}`;
     }
 
     private constructor(config: CrossmintEmbedConfig) {

--- a/src/evm-wallet-adapter/adapter.ts
+++ b/src/evm-wallet-adapter/adapter.ts
@@ -4,6 +4,7 @@ import CrossmintEmbed from "../CrossmintEmbed";
 import { CROSSMINT_LOGO_21x21, CrossmintWalletName } from "../consts/branding";
 import { BlockchainTypes, CrossmintEmbedConfig, CrossmintEmbedParams } from "../types";
 import { buildConfig } from "../utils/config";
+import { WalletPublicKeyError, WalletSignTransactionError, WalletWindowClosedError } from "@solana/wallet-adapter-base";
 
 export class CrossmintEVMWalletAdapter {
     name = CrossmintWalletName;
@@ -11,7 +12,7 @@ export class CrossmintEVMWalletAdapter {
     icon = CROSSMINT_LOGO_21x21;
 
     private _connecting: boolean;
-    private _publicKey: string | null;
+    private _publicKeys: string[];
 
     private _config: CrossmintEmbedConfig;
     private _client?: CrossmintEmbed;
@@ -20,13 +21,23 @@ export class CrossmintEVMWalletAdapter {
         params: Omit<CrossmintEmbedParams, "chain"> & { chain: BlockchainTypes.ETHEREUM | BlockchainTypes.POLYGON }
     ) {
         this._connecting = false;
-        this._publicKey = null;
+        this._publicKeys = [];
 
         this._config = buildConfig({ ...params });
     }
 
     get publicKey(): string | null {
-        return this._publicKey;
+        if (this._publicKeys.length == 0)
+            return null;
+
+        return this._publicKeys[0];
+    }
+
+    get publicKeys(): string[] | null {
+        if (this._publicKeys.length == 0)
+            return null;
+
+        return this._publicKeys;
     }
 
     get connecting(): boolean {
@@ -34,7 +45,7 @@ export class CrossmintEVMWalletAdapter {
     }
 
     get connected(): boolean {
-        return this._publicKey !== null && this._publicKey !== undefined;
+        return this._publicKeys.length > 0;
     }
 
     async connect(): Promise<string | undefined> {
@@ -45,26 +56,30 @@ export class CrossmintEVMWalletAdapter {
 
             const client = CrossmintEmbed.init(this._config);
 
-            const account = await client.login();
+            const accounts = await client.login();
 
-            if (account === null) {
-                throw new Error("User rejected the request");
+            if (accounts === null) {
+                throw new WalletWindowClosedError("User rejected the request");
             }
-            if (account === undefined) {
-                throw new Error("User rejected the request or closed the window");
+            if (accounts === undefined || accounts.length === 0) {
+                throw new WalletWindowClosedError("User rejected the request or closed the window");
             }
 
-            let publicKey: string;
-            try {
-                publicKey = ethers.utils.getAddress(account);
-            } catch (error: any) {
-                throw new Error(error?.message, error);
+            const publicKeys: string[] = [];
+            for (const account of accounts) {
+                try {
+                    publicKeys.push(ethers.utils.getAddress(account));
+                }
+                catch (error: any) {
+                    throw new WalletPublicKeyError(error?.message, error);
+                }
             }
 
             this._client = client;
-            this._publicKey = publicKey;
+            this._publicKeys = publicKeys;
 
-            return this._publicKey;
+            // TODO: is this behavior ok?
+            return this._publicKeys[0];
 
             // this.emit("connect", publicKey);
         } catch (error: any) {
@@ -78,22 +93,22 @@ export class CrossmintEVMWalletAdapter {
         this._client?.cleanUp();
 
         this._client = undefined;
-        this._publicKey = null;
+        this._publicKeys = [];
 
         // this.emit("disconnect");
     }
 
-    async signMessage(message: string): Promise<string> {
+    async signMessage(message: string, publicKey?: string): Promise<string> {
         try {
             if (!this._client || !this.connected) throw new Error("Not connected");
 
-            const signedMessage = await this._client.signMessage(new TextEncoder().encode(message));
+            const signedMessage = await this._client.signMessage(new TextEncoder().encode(message), publicKey);
 
             if (signedMessage === null) {
-                throw new Error("User rejected the request");
+                throw new WalletWindowClosedError("User rejected the request");
             }
             if (signedMessage === undefined) {
-                throw new Error("User rejected the request or closed the window");
+                throw new WalletSignTransactionError("User rejected the request or closed the window");
             }
 
             return new TextDecoder().decode(signedMessage);
@@ -101,5 +116,17 @@ export class CrossmintEVMWalletAdapter {
             // this.emit("error", error);
             throw error;
         }
+    }
+
+    async signMessageWithAllAddresses(message: string): Promise<{[publicKey: string]: string}> {
+        if (!this._client || !this.connected) throw new Error("Not connected");
+
+        const signedMessages = await Promise.all(this._publicKeys.map(async (publicKey) => {
+            const signedMessage = await this.signMessage(message, publicKey);
+            return [publicKey, signedMessage];
+        }));
+
+        return signedMessages.reduce((acc, [publicKey, signedMessage]) =>
+            ({...acc, [publicKey]: signedMessage}), {});
     }
 }

--- a/src/solana-wallet-adapter/adapter.ts
+++ b/src/solana-wallet-adapter/adapter.ts
@@ -68,14 +68,16 @@ export class CrossmintSolanaWalletAdapter extends BaseMessageSignerWalletAdapter
 
             const client = CrossmintEmbed.init(this._config);
 
-            const account = await client.login();
+            const accounts = await client.login();
 
-            if (account === null) {
+            if (accounts === null) {
                 throw new WalletWindowClosedError("User rejected the request");
             }
-            if (account === undefined) {
-                throw new WalletNotConnectedError("User rejected the request or closed the window");
+            if (accounts === undefined || accounts.length === 0) {
+                throw new WalletWindowClosedError("User rejected the request or closed the window");
             }
+
+            const account = accounts[0];
 
             let publicKey: PublicKey;
             try {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,7 +11,8 @@ export interface CrossmintEmbedParams {
      * Project ID
      * This will return data from the user's Crossmint account under the Project ID.
      * Get yours at {@link https://console.crossmint.com | Developer Dashboard}
-     * If you don't have a Project ID, you can exclude this parameter or set it to undefined.
+     * If you don't have a Project ID, you can exclude this parameter, set it to undefined
+     * or set it to "all" to get all wallets from all projects.
      */
     projectId?: string;
 


### PR DESCRIPTION
Add the ability to fetch and sign using all wallets as some users may have some entities in one wallet but not in the project-scoped wallet.