### PR TITLE
Remove `apiKey` param

### DIFF
--- a/src/CrossmintEmbed.ts
+++ b/src/CrossmintEmbed.ts
@@ -205,7 +205,7 @@ export default class CrossmintEmbed {
         request: CrossmintEmbedRequestType,
         data?: Omit<
             CrossmintEmbedSignMessageData | CrossmintEmbedRequestAccountData,
-            "libVersion" | "chain" | "apiKey" | "siteMetadata"
+            "libVersion" | "chain" | "siteMetadata"
         >,
         targetOrigin: string = "*"
     ) {
@@ -216,7 +216,6 @@ export default class CrossmintEmbed {
                     libVersion: this._config.libVersion,
                     chain: this._config.chain,
                     projectId: this._config.projectId,
-                    apiKey: this._config.apiKey,
                     siteMetadata: await buildSiteMetadata(this._config.appMetadata),
                     ...data,
                 },

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,12 +2,6 @@ import { BlockchainTypes } from ".";
 
 export interface CrossmintEmbedParams {
     /**
-     * API key
-     * Get yours at {@link https://www.crossmint.com/console/projects/apiKeys | Developer Dashboard}
-     */
-    apiKey: string;
-
-    /**
      * Project ID
      * This will return data from the user's Crossmint account under the Project ID.
      * Get yours at {@link https://www.crossmint.com/console/projects/apiKeys | Developer Dashboard}
@@ -38,7 +32,6 @@ export interface AppMetadata {
 export interface CrossmintEmbedConfig {
     libVersion: string;
 
-    apiKey: string;
     projectId?: string;
 
     chain: BlockchainTypes;

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -20,7 +20,6 @@ export interface CrossmintEmbedBaseRequest<CrossmintEmbedBaseRequestDataType> {
 export interface CrossmintEmbedBaseRequestData {
     libVersion: string;
     chain: BlockchainTypes;
-    apiKey: string;
     siteMetadata: SiteMetadata;
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,7 +4,6 @@ import { CrossmintEmbedConfig, CrossmintEmbedParams, CrossmintEnvironment } from
 export function buildConfig(params: CrossmintEmbedParams): CrossmintEmbedConfig {
     const ret: CrossmintEmbedConfig = {
         libVersion: LIB_VERSION,
-        apiKey: params.apiKey,
         projectId: params.projectId,
         environment: params.environment || CrossmintEnvironment.PROD,
         autoConnect: params.autoConnect ?? true,


### PR DESCRIPTION
The `apiKey` parameter was deprecated and should no longer be used.