### PR TITLE
Add support for `forceWalletSelection`

### DIFF
--- a/src/CrossmintEmbed.ts
+++ b/src/CrossmintEmbed.ts
@@ -14,10 +14,11 @@ export default class CrossmintEmbed {
     private _config: CrossmintEmbedConfig;
 
     private get _frameUrl() {
-        const { environment, chain, projectId } = this._config;
+        const { environment, chain, projectId, forceWalletSelection } = this._config;
         const projectIdQueryParam = projectId != null ? `&projectId=${projectId}` : "";
+        const forceWalletSelectionQueryParam = forceWalletSelection != null ? `&forceWalletSelection=${forceWalletSelection}` : "";
 
-        return `${environment}/2023-06-09/frame?chain=${chain}${projectIdQueryParam}`;
+        return `${environment}/2023-06-09/frame?chain=${chain}${projectIdQueryParam}${forceWalletSelectionQueryParam}`;
     }
 
     private constructor(config: CrossmintEmbedConfig) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,7 @@ export interface CrossmintEmbedParams {
      * or set it to "all" to get all wallets from all projects.
      */
     projectId?: string;
+    forceWalletSelection?: boolean;
 
     chain: BlockchainTypes;
 
@@ -33,6 +34,7 @@ export interface CrossmintEmbedConfig {
     libVersion: string;
 
     projectId?: string;
+    forceWalletSelection?: boolean;
 
     chain: BlockchainTypes;
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,6 +10,7 @@ export function buildConfig(params: CrossmintEmbedParams): CrossmintEmbedConfig 
         maxTimeAutoConnectMs: params.maxTimeAutoConnectMs || 300,
         appMetadata: params.appMetadata,
         chain: params.chain,
+        forceWalletSelection: params.forceWalletSelection,
     };
 
     return ret;


### PR DESCRIPTION
Add a feature where a user can automatically connect the default wallet for a project instead of having to select which wallet they would like connected.